### PR TITLE
Export exact stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ test/testLocal
 test/testRemote
 test/testWrite
 test/output.bw
-example_output.bw
+test/example_output.bw
 test/exampleWrite

--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,7 @@ test/exampleWrite: libBigWig.so
 	$(CC) -o $@ -I. -L. $(CFLAGS) test/exampleWrite.c -lBigWig $(LIBS) -Wl,-rpath .
 
 test: test/testLocal test/testRemote test/testWrite test/testLocal test/exampleWrite
-	./test/testLocal test/test.bw
-	./test/testRemote http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeMapability/wgEncodeCrgMapabilityAlign50mer.bigWig
-	./test/testWrite test/test.bw test/output.bw
-	./test/testLocal test/output.bw
-	rm -f test/output.bw
-	./test/exampleWrite
-	rm -f example_output.bw
+	./test/test.py
 
 clean:
 	rm -f *.o libBigWig.a libBigWig.so *.pico test/testLocal test/testRemote test/testWrite test/exampleWrite example_output.bw

--- a/bigWig.h
+++ b/bigWig.h
@@ -41,7 +41,7 @@
 /*!
  * The library version number
  */
-#define LIBBIGWIG_VERSION 0.1.4
+#define LIBBIGWIG_VERSION 0.1.5
 
 /*!
  * The magic number of a bigWig file.

--- a/bigWig.h
+++ b/bigWig.h
@@ -288,6 +288,20 @@ bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, char *chrom, uint32_t st
  */
 double *bwStats(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type);
 
+/*!
+ * @brief Determines per-interval statistics
+ * Can determine mean/min/max/coverage/standard deviation of values in one or more intervals. You can optionally give it an interval and ask for values from X number of sub-intervals. The difference with bwStats is that zoom levels are never used.
+ * @param fp The file from which to extract statistics.
+ * @param chrom A valid chromosome name.
+ * @param start The start position of the interval. This is 0-based half open, so 0 is the first base.
+ * @param end The end position of the interval. Again, this is 0-based half open, so 100 will include the 100th base...which is at position 99.
+ * @param nBins The number of bins within the interval to calculate statistics for.
+ * @param type The type of statistic.
+ * @see bwStatsType
+ * @return A pointer to an array of double precission floating point values. Note that bigWig files only hold 32-bit values, so this is done to help prevent overflows.
+*/
+double *bwStatsFromFull(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type);
+
 //Writer functions
 
 /*!

--- a/bwStats.c
+++ b/bwStats.c
@@ -135,7 +135,6 @@ error:
 }
 
 //On error, errno is set to ENOMEM and NaN is returned (though NaN can be returned normally)
-//Does UCSC compensate for partial block/range overlap?
 static double blockMean(bigWigFile_t *fp, bwOverlapBlock_t *blocks, uint32_t tid, uint32_t start, uint32_t end) {
     uint32_t i, j;
     double output = 0.0, coverage = 0.0;
@@ -177,7 +176,7 @@ static double intMean(bwOverlappingIntervals_t* ints, uint32_t start, uint32_t e
         if(ints->start[i] < start) start_use = start;
         if(ints->end[i] > end) end_use = end;
         nBases += end_use-start_use;
-        sum += (end_use-start_use)*ints->value[i];
+        sum += (end_use-start_use)*((double) ints->value[i]);
     }
 
     return sum/nBases;

--- a/test/exampleWrite.c
+++ b/test/exampleWrite.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    fp = bwOpen("example_output.bw", NULL, "w");
+    fp = bwOpen("test/example_output.bw", NULL, "w");
     if(!fp) {
         fprintf(stderr, "An error occurred while opening example_output.bw for writingn\n");
         return 1;

--- a/test/test.py
+++ b/test/test.py
@@ -26,9 +26,9 @@ assert(md5sum == "9ccecd6c32ff31042714c1da3c0d0eba")
 p1 = check_call(["./test/testWrite", "test/test.bw", "test/output.bw"])
 assert(p1 == 0)
 try:
-    p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+    p2 = Popen(["md5sum", "test/output.bw"], stdout=PIPE)
 except:
-    p2 = Popen(["md5"], stdin=p1.stdout, stdout=PIPE)
+    p2 = Popen(["md5", "test/output.bw"], stdout=PIPE)
 md5sum = p2.communicate()[0].strip().split()[0]
 assert(md5sum == "8e116bd114ffd2eb625011d451329c03")
 remove("test/output.bw")
@@ -37,9 +37,9 @@ remove("test/output.bw")
 p1 = check_call(["./test/exampleWrite"])
 assert(p1 == 0)
 try:
-    p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+    p2 = Popen(["md5sum", "test/example_output.bw"], stdout=PIPE)
 except:
-    p2 = Popen(["md5"], stdin=p1.stdout, stdout=PIPE)
+    p2 = Popen(["md5", "test/example_output.bw"], stdout=PIPE)
 md5sum = p2.communicate()[0].strip().split()[0]
 assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
 remove("test/example_output.bw")

--- a/test/test.py
+++ b/test/test.py
@@ -29,9 +29,13 @@ try:
     p2 = Popen(["md5sum", "test/output.bw"], stdout=PIPE)
 except:
     p2 = Popen(["md5", "test/output.bw"], stdout=PIPE)
-md5sum = p2.communicate()[0].strip().split()[0]
-print(md5sum)
-#assert(md5sum == "8e116bd114ffd2eb625011d451329c03")
+md5sum = p2.communicate()[0].strip()
+md5sumuse = md5sum.split()[0]
+try:
+    assert(md5sumuse == "8e116bd114ffd2eb625011d451329c03")
+except:
+    md5sum = md5sum.split(" ")[-1]
+    assert(md5sum == "8e116bd114ffd2eb625011d451329c03")
 remove("test/output.bw")
 
 # test creation from scratch with multiple interval types
@@ -41,7 +45,11 @@ try:
     p2 = Popen(["md5sum", "test/example_output.bw"], stdout=PIPE)
 except:
     p2 = Popen(["md5", "test/example_output.bw"], stdout=PIPE)
-md5sum = p2.communicate()[0].strip().split()[0]
-print(md5sum)
-#assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
+md5sum = p2.communicate()[0].strip()
+md5sumuse = md5sum.split()[0]
+try:
+    assert(md5sumuse == "ef104f198c6ce8310acc149d0377fc16")
+except:
+    md5sum = md5sum.split(" ")[-1]
+    assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
 remove("test/example_output.bw")

--- a/test/test.py
+++ b/test/test.py
@@ -30,7 +30,8 @@ try:
 except:
     p2 = Popen(["md5", "test/output.bw"], stdout=PIPE)
 md5sum = p2.communicate()[0].strip().split()[0]
-assert(md5sum == "8e116bd114ffd2eb625011d451329c03")
+print(md5sum)
+#assert(md5sum == "8e116bd114ffd2eb625011d451329c03")
 remove("test/output.bw")
 
 # test creation from scratch with multiple interval types
@@ -40,6 +41,7 @@ try:
     p2 = Popen(["md5sum", "test/example_output.bw"], stdout=PIPE)
 except:
     p2 = Popen(["md5", "test/example_output.bw"], stdout=PIPE)
-md5sum = p2.communicate()[0].strip().split()[0]
+print(md5sum)
+#md5sum = p2.communicate()[0].strip().split()[0]
 assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
 remove("test/example_output.bw")

--- a/test/test.py
+++ b/test/test.py
@@ -6,20 +6,29 @@ from os import remove
 
 # local test
 p1 = Popen(["./test/testLocal", "test/test.bw"], stdout=PIPE)
-p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+try:
+    p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+except:
+    p2 = Popen(["md5"], stdin=p1.stdout, stdout=PIPE)
 md5sum = p2.communicate()[0].strip().split()[0]
 assert(md5sum == "a15cbf0021f3e80d9ddfd9dbe78057cf")
 
 # remote http test
 p1 = Popen(["./test/testRemote", "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeMapability/wgEncodeCrgMapabilityAlign50mer.bigWig"], stdout=PIPE)
-p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+try:
+    p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+except:
+    p2 = Popen(["md5"], stdin=p1.stdout, stdout=PIPE)
 md5sum = p2.communicate()[0].strip().split()[0]
 assert(md5sum == "9ccecd6c32ff31042714c1da3c0d0eba")
 
 # test recreating a file
 p1 = check_call(["./test/testWrite", "test/test.bw", "test/output.bw"])
 assert(p1 == 0)
-p2 = Popen(["md5sum", "test/output.bw"], stdout=PIPE)
+try:
+    p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+except:
+    p2 = Popen(["md5"], stdin=p1.stdout, stdout=PIPE)
 md5sum = p2.communicate()[0].strip().split()[0]
 assert(md5sum == "8e116bd114ffd2eb625011d451329c03")
 remove("test/output.bw")
@@ -27,7 +36,10 @@ remove("test/output.bw")
 # test creation from scratch with multiple interval types
 p1 = check_call(["./test/exampleWrite"])
 assert(p1 == 0)
-p2 = Popen(["md5sum", "test/example_output.bw"], stdout=PIPE)
+try:
+    p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+except:
+    p2 = Popen(["md5"], stdin=p1.stdout, stdout=PIPE)
 md5sum = p2.communicate()[0].strip().split()[0]
 assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
 remove("test/example_output.bw")

--- a/test/test.py
+++ b/test/test.py
@@ -41,7 +41,7 @@ try:
     p2 = Popen(["md5sum", "test/example_output.bw"], stdout=PIPE)
 except:
     p2 = Popen(["md5", "test/example_output.bw"], stdout=PIPE)
+md5sum = p2.communicate()[0].strip().split()[0]
 print(md5sum)
-#md5sum = p2.communicate()[0].strip().split()[0]
-assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
+#assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
 remove("test/example_output.bw")

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+from subprocess import Popen, PIPE, check_call
+from os import remove
+
+# N.B., this MUST be run from within the source directory!
+
+# local test
+p1 = Popen(["./test/testLocal", "test/test.bw"], stdout=PIPE)
+p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+md5sum = p2.communicate()[0].strip().split()[0]
+assert(md5sum == "a15cbf0021f3e80d9ddfd9dbe78057cf")
+
+# remote http test
+p1 = Popen(["./test/testRemote", "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeMapability/wgEncodeCrgMapabilityAlign50mer.bigWig"], stdout=PIPE)
+p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+md5sum = p2.communicate()[0].strip().split()[0]
+assert(md5sum == "9ccecd6c32ff31042714c1da3c0d0eba")
+
+# test recreating a file
+p1 = check_call(["./test/testWrite", "test/test.bw", "test/output.bw"])
+assert(p1 == 0)
+p2 = Popen(["md5sum", "test/output.bw"], stdout=PIPE)
+md5sum = p2.communicate()[0].strip().split()[0]
+assert(md5sum == "8e116bd114ffd2eb625011d451329c03")
+remove("test/output.bw")
+
+# test creation from scratch with multiple interval types
+p1 = check_call(["./test/exampleWrite"])
+assert(p1 == 0)
+p2 = Popen(["md5sum", "test/example_output.bw"], stdout=PIPE)
+md5sum = p2.communicate()[0].strip().split()[0]
+assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
+remove("test/example_output.bw")


### PR DESCRIPTION
Export `bwStatsFromFull`, which was requested for pyBigWig.

Increased the precision of the `mean` statistic, which previously used a `float` rather than a `double` (everything else should be using `double`s internally, even though bigWig files only store `float`s).