### PR TITLE
Chrom non leaves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/testWrite
 test/output.bw
 test/example_output.bw
 test/exampleWrite
+test/testRemoteManyContigs

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ libBigWig.so: $(OBJS:.o=.pico)
 test/testLocal: libBigWig.a
 	$(CC) -o $@ -I. $(CFLAGS) test/testLocal.c libBigWig.a $(LIBS)
 
+test/testRemoteManyContigs: libBigWig.a
+	$(CC) -o $@ -I. $(CFLAGS) test/testRemoteManyContigs.c libBigWig.a $(LIBS)
+
 test/testRemote: libBigWig.a
 	$(CC) -o $@ -I. $(CFLAGS) test/testRemote.c libBigWig.a $(LIBS)
 
@@ -55,11 +58,11 @@ test/testWrite: libBigWig.a
 test/exampleWrite: libBigWig.so
 	$(CC) -o $@ -I. -L. $(CFLAGS) test/exampleWrite.c -lBigWig $(LIBS) -Wl,-rpath .
 
-test: test/testLocal test/testRemote test/testWrite test/testLocal test/exampleWrite
+test: test/testLocal test/testRemote test/testWrite test/testLocal test/exampleWrite test/testRemoteManyContigs
 	./test/test.py
 
 clean:
-	rm -f *.o libBigWig.a libBigWig.so *.pico test/testLocal test/testRemote test/testWrite test/exampleWrite example_output.bw
+	rm -f *.o libBigWig.a libBigWig.so *.pico test/testLocal test/testRemote test/testWrite test/exampleWrite test/testRemoteManyContigs example_output.bw
 
 install: libBigWig.a libBigWig.so
 	install -d $(prefix)/lib $(prefix)/include

--- a/bigWig.h
+++ b/bigWig.h
@@ -41,7 +41,7 @@
 /*!
  * The library version number
  */
-#define LIBBIGWIG_VERSION 0.1.5
+#define LIBBIGWIG_VERSION 0.1.6
 
 /*!
  * The magic number of a bigWig file.

--- a/bwRead.c
+++ b/bwRead.c
@@ -207,7 +207,7 @@ static uint64_t readChromNonLeaf(bigWigFile_t *bw, chromList_t *cl, uint32_t key
     if(bwRead((void*) &nVals, sizeof(uint16_t), 1, bw) != 1) return -1;
 
     //These aren't actually used for anything, we just skip to the next block...
-    offset = nVals * (keySize + 8) + bw->URL->filePos + bw->URL->bufPos;
+    offset = nVals * (keySize + 8) + bwTell(bw);
 
     if(bwSetPos(bw, offset)) return -1;
     return readChromBlock(bw, cl, keySize);

--- a/test/test.py
+++ b/test/test.py
@@ -53,3 +53,12 @@ except:
     md5sum = md5sum.split(" ")[-1]
     assert(md5sum == "ef104f198c6ce8310acc149d0377fc16")
 remove("test/example_output.bw")
+
+# Ensure that we can properly parse chromosome trees with non-leaf nodes
+p1 = Popen(["./test/testRemoteManyContigs", "ftp://hgdownload.cse.ucsc.edu/gbdb/dm6/bbi/gc5BaseBw/gc5Base.bw"], stdout=PIPE)
+try:
+    p2 = Popen(["md5sum"], stdin=p1.stdout, stdout=PIPE)
+except:
+    p2 = Popen(["md5"], stdin=p1.stdout, stdout=PIPE)
+md5sum = p2.communicate()[0].strip().split()[0]
+assert(md5sum == "a15a3120c03ba44a81b025ebd411966c")

--- a/test/testRemoteManyContigs.c
+++ b/test/testRemoteManyContigs.c
@@ -1,0 +1,46 @@
+#include "bigWig.h"
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <assert.h>
+
+//This is an example call back function
+CURLcode callBack(CURL *curl) {
+    CURLcode rv;
+
+    rv = curl_easy_setopt(curl, CURLOPT_USERNAME, "anonymous");
+    if(rv != CURLE_OK) return rv;
+
+    rv = curl_easy_setopt(curl, CURLOPT_PASSWORD, "libBigWig@github.com");
+    return rv;
+}
+
+int main(int argc, char *argv[]) {
+    bigWigFile_t *fp = NULL;
+    int64_t i;
+
+    if(argc != 2) {
+        fprintf(stderr, "Usage: %s {file.bw|URL://path/file.bw}\n", argv[0]);
+        return 1;
+    }
+
+    if(bwInit(1<<17) != 0) {
+        fprintf(stderr, "Received an error in bwInit\n");
+        return 1;
+    }
+
+    fp = bwOpen(argv[1], callBack, "r");
+    if(!fp) {
+        fprintf(stderr, "An error occured while opening %s\n", argv[1]);
+        return 1;
+    }
+
+    //Return the number of chromosomes/contigs
+    for(i=0; i<fp->cl->nKeys; i++) {
+        printf("%s\t%"PRIu32"\n", fp->cl->chrom[i], fp->cl->len[i]);
+    }
+
+    bwClose(fp);
+    bwCleanup();
+    return 0;
+}


### PR DESCRIPTION
When bigWig files contain a large number of contigs, they're stored in multiple blocks in the header. The offset wasn't being handled properly for local files in this case. These edits seem to fix that problem.