### PR TITLE
changes for CXX compat

### DIFF
--- a/bigWig.h
+++ b/bigWig.h
@@ -3,6 +3,10 @@
 #include <inttypes.h>
 #include <zlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*! \mainpage libBigWig
  *
  * \section Introduction
@@ -71,7 +75,6 @@ enum bwStatsType {
     doesNotExist = -1,
     mean = 0,
     average = 0,
-    std = 1,
     stdev = 1,
     dev = 1,
     max = 2,
@@ -425,3 +428,7 @@ int bwAddIntervalSpanSteps(bigWigFile_t *fp, char *chrom, uint32_t start, uint32
  * @see bwAddIntervalSpanSteps
  */
 int bwAppendIntervalSpanSteps(bigWigFile_t *fp, float *values, uint32_t n);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This PR makes a few small changes to `bigWig.h` to allow C++ compatibility.

- The header guards allow for linking to c++ libraries
- Removal of `std` prevents a clash with the C++ `std` namespace. `stdev` remains in libBigWig and should be sufficient, but formally this could be a breaking change.

Will release an R binding to `libBigWig` via `Rcpp` imminently.