### PR TITLE
Force use of Python2.7 in case Python 3 is lurking

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 from subprocess import Popen, PIPE, check_call
 from os import remove
 


### PR DESCRIPTION
This allowed me to pass tests on my laptop, as discussed in Issue #15 