### PR TITLE
Fix creation of bigWig files with very very large intervals

### DIFF
--- a/bigWig.h
+++ b/bigWig.h
@@ -53,7 +53,7 @@ extern "C" {
 /*!
  * The library version number
  */
-#define LIBBIGWIG_VERSION 0.3.0
+#define LIBBIGWIG_VERSION 0.3.1
 
 /*!
  * The magic number of a bigWig file.

--- a/bwWrite.c
+++ b/bwWrite.c
@@ -780,7 +780,7 @@ int writeIndex(bigWigFile_t *fp) {
 //This may or may not produce the requested number of zoom levels
 int makeZoomLevels(bigWigFile_t *fp) {
     uint32_t meanBinSize, i;
-    uint32_t multiplier = 4, zoom = 10;
+    uint32_t multiplier = 4, zoom = 10, maxZoom = 0;
     uint16_t nLevels = 0;
 
     meanBinSize = ((double) fp->writeBuffer->runningWidthSum)/(fp->writeBuffer->nEntries);
@@ -801,7 +801,15 @@ int makeZoomLevels(bigWigFile_t *fp) {
     if(!fp->hdr->zoomHdrs->indexOffset) return 4;
     if(!fp->hdr->zoomHdrs->idx) return 5;
 
+    //There's no point in having a zoom level larger than the largest chromosome
+    //This will none the less allow at least one zoom level, which is generally needed for IGV et al.
+    for(i=0; i<fp->cl->nKeys; i++) {
+        if(fp->cl->len[i] > maxZoom) maxZoom = fp->cl->len[i];
+    }
+    if(zoom > maxZoom) zoom = maxZoom;
+
     for(i=0; i<fp->hdr->nLevels; i++) {
+        if(zoom > maxZoom) break; //prevent absurdly large zoom levels
         fp->hdr->zoomHdrs->level[i] = zoom;
         nLevels++;
         if(((uint32_t)-1)/multiplier < zoom) break;

--- a/bwWrite.c
+++ b/bwWrite.c
@@ -887,6 +887,10 @@ uint32_t updateInterval(bigWigFile_t *fp, bwZoomBuffer_t *buffer, double *sum, d
     uint32_t rv = 0, offset = 0;
     if(!buffer) return 0;
     if(buffer->l+32 >= buffer->m) return 0;
+
+    //Make sure that we don't overflow a uint32_t by adding some huge value to start
+    if(start + size < start) size = ((uint32_t) -1) - start;
+
     if(buffer->l) {
         offset = buffer->l/32;
     } else {


### PR DESCRIPTION
If the mean interval size is in tens of megabases, then it can occur that the zoom levels quickly become larger than the largest chromosome size. This also has the affect of possibly overflowing a `uint32_t` when there's only one interval on a chromosome, which causes the infinite loop observed in #18. This PR fixes this behavior. First, the numeric overflow is caught, so the infinite loop is avoided. Secondly, absurdly large zoom levels are avoided by setting the largest possible zoom level to the size of the largest chromosome/contig.