### PR TITLE
removing redundant conditions in if else

### DIFF
--- a/bwValues.c
+++ b/bwValues.c
@@ -158,7 +158,7 @@ static bwOverlapBlock_t *overlapsLeaf(bwRTreeNode_t *node, uint32_t tid, uint32_
 
         for(i=0; i<node->nChildren; i++) {
             if(tid < node->chrIdxStart[i]) break;
-            if(tid < node->chrIdxStart[i] || tid > node->chrIdxEnd[i]) continue;
+            if(tid > node->chrIdxEnd[i]) continue;
             if(node->chrIdxStart[i] != node->chrIdxEnd[i]) {
                 if(tid == node->chrIdxStart[i]) {
                     if(node->baseStart[i] >= end) continue;
@@ -227,7 +227,7 @@ static bwOverlapBlock_t *overlapsNonLeaf(bigWigFile_t *fp, bwRTreeNode_t *node, 
 
     for(i=0; i<node->nChildren; i++) {
         if(tid < node->chrIdxStart[i]) break;
-        if(tid < node->chrIdxStart[i] || tid > node->chrIdxEnd[i]) continue;
+        if(tid > node->chrIdxEnd[i]) continue;
         if(node->chrIdxStart[i] != node->chrIdxEnd[i]) { //child spans contigs
             if(tid == node->chrIdxStart[i]) {
                 if(node->baseStart[i] >= end) continue;


### PR DESCRIPTION
1) When an if condition leads to a break I cannot see a reason as to why it will be satisfied in another if condition latter .
 2) Also to get chrom id easily and in a faster way, we could use an array with indexes as keys 
3) RtreeIndex could simply return indexOffset+48 as it is always a fixed size header for the R-tree.