### PR TITLE
Raw get values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ libBigWig.so: $(OBJS:.o=.pico)
 test/testLocal: libBigWig.a
 	$(CC) -o $@ -I. $(CFLAGS) test/testLocal.c libBigWig.a $(LIBS)
 
+test/testValues: libBigWig.a test/testValues.c
+	$(CC) -o $@ -I. $(CFLAGS) test/testValues.c libBigWig.a $(LIBS)
+
 test/testRemoteManyContigs: libBigWig.a
 	$(CC) -o $@ -I. $(CFLAGS) test/testRemoteManyContigs.c libBigWig.a $(LIBS)
 
@@ -64,11 +67,11 @@ test/testBigBed: libBigWig.a
 test/testIterator: libBigWig.a
 	$(CC) -o $@ -I. $(CFLAGS) test/testIterator.c libBigWig.a $(LIBS)
 
-test: test/testLocal test/testRemote test/testWrite test/testLocal test/exampleWrite test/testRemoteManyContigs test/testBigBed test/testIterator
+test: test/testLocal test/testRemote test/testValues test/testWrite test/testLocal test/exampleWrite test/testRemoteManyContigs test/testBigBed test/testIterator
 	./test/test.py
 
 clean:
-	rm -f *.o libBigWig.a libBigWig.so *.pico test/testLocal test/testRemote test/testWrite test/exampleWrite test/testRemoteManyContigs test/testBigBed test/testIterator example_output.bw
+	rm -f *.o libBigWig.a libBigWig.so *.pico test/testLocal test/testRemote test/testWrite test/testValues test/exampleWrite test/testRemoteManyContigs test/testBigBed test/testIterator example_output.bw test/output2.bw
 
 install: libBigWig.a libBigWig.so
 	install -d $(prefix)/lib $(prefix)/include

--- a/bigWig.h
+++ b/bigWig.h
@@ -444,6 +444,9 @@ void bwIteratorDestroy(bwOverlapIterator_t *iter);
  */
 bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int includeNA);
 
+
+float *bwGetOverlappingValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end);
+
 /*!
  * @brief Determines per-interval bigWig statistics
  * Can determine mean/min/max/coverage/standard deviation of values in one or more intervals in a bigWig file. You can optionally give it an interval and ask for values from X number of sub-intervals.

--- a/bigWig.h
+++ b/bigWig.h
@@ -445,7 +445,7 @@ void bwIteratorDestroy(bwOverlapIterator_t *iter);
 bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int includeNA);
 
 
-void bwGetOverlappingValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, float *output);
+void bwGetOverlappingValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, float missingVal, float *output);
 
 /*!
  * @brief Determines per-interval bigWig statistics

--- a/bigWig.h
+++ b/bigWig.h
@@ -445,7 +445,7 @@ void bwIteratorDestroy(bwOverlapIterator_t *iter);
 bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int includeNA);
 
 
-float *bwGetOverlappingValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end);
+void bwGetOverlappingValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, float *output);
 
 /*!
  * @brief Determines per-interval bigWig statistics

--- a/bigWig.h
+++ b/bigWig.h
@@ -445,6 +445,20 @@ void bwIteratorDestroy(bwOverlapIterator_t *iter);
 bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int includeNA);
 
 
+/*!
+ * @brief fill a pre-allocated buffer with per-base bigWig values.
+ * Given an interval (e.g., chr1:100-200), set the value at each position in a bigWig file
+ * such that array index 0 will be position 100 from chromosome 1.
+ * Positions without associated values are set to missingVal.
+ * @param fp A valid bigWigFile_t pointer.
+ * @param chrom A valid chromosome name.
+ * @param start The start position of the interval. This is 0-based half open, so 0 is the first base.
+ * @param end The end position of the interval. Again, this is 0-based half open, so 100 will include the 100th base...which is at position 99.
+ * @param missingVal portions of the query region without data are set to this value.
+ * @param output a buffer which must be allocated to at least size end-start.
+ * @see bwGetValues
+ * @see bwGetOverlappingIntervals
+ */
 void bwGetOverlappingValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, float missingVal, float *output);
 
 /*!

--- a/bwValues.c
+++ b/bwValues.c
@@ -465,8 +465,8 @@ float *bwGetOverlappingValuesCore(bigWigFile_t *fp, bwOverlapBlock_t *o, uint32_
                 break;
             }
 
-            if(end <= ostart || start >= oend) continue;
-            for(i=(start > ostart ? 0: ostart - start); i<(end > oend ? L: end - start); i++) {
+	    if(end <= ostart || start >= oend) continue;
+            for(i=(start < ostart ? 0: (ostart - start)); i<(end > oend ? L: (end - ostart)); i++) {
                     output[i] =  value;
             }
         }

--- a/bwValues.c
+++ b/bwValues.c
@@ -388,7 +388,7 @@ error:
     return NULL;
 }
 
-void bwGetOverlappingValuesCore(bigWigFile_t *fp, bwOverlapBlock_t *o, uint32_t tid, uint32_t ostart, uint32_t oend, float *output) {
+void bwGetOverlappingValuesCore(bigWigFile_t *fp, bwOverlapBlock_t *o, uint32_t tid, uint32_t ostart, uint32_t oend, float missingVal, float *output) {
     uint64_t L = oend - ostart;
     uLongf sz = fp->hdr->bufSize, tmp;
     uint64_t i, k;
@@ -399,7 +399,7 @@ void bwGetOverlappingValuesCore(bigWigFile_t *fp, bwOverlapBlock_t *o, uint32_t 
     uint32_t start = 0, end , *p;
     bwDataHeader_t hdr;
     void *buf = NULL, *compBuf = NULL;
-    for(i=0; i < L; i++) { output[i] = NAN; }
+    for(i=0; i < L; i++) { output[i] = missingVal; }
     if ((!o) || (!o->n)){
         return ;
     }
@@ -670,12 +670,12 @@ bwOverlappingIntervals_t *bwGetOverlappingIntervals(bigWigFile_t *fp, char *chro
     return output;
 }
 
-void bwGetOverlappingValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, float *output) {
+void bwGetOverlappingValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, float missingVal, float *output) {
     uint32_t tid = bwGetTid(fp, chrom);
     if(tid == (uint32_t) -1) return;
     bwOverlapBlock_t *blocks = bwGetOverlappingBlocks(fp, chrom, start, end);
     if(!blocks) return;
-    bwGetOverlappingValuesCore(fp, blocks, tid, start, end, output);
+    bwGetOverlappingValuesCore(fp, blocks, tid, start, end, missingVal, output);
     destroyBWOverlapBlock(blocks);
 }
 

--- a/bwValues.c
+++ b/bwValues.c
@@ -470,7 +470,7 @@ void bwGetOverlappingValuesCore(bigWigFile_t *fp, bwOverlapBlock_t *o, uint32_t 
             lo = start < ostart ? 0: (start - ostart);
             hi = end > oend ? L: (end - ostart);
             for(k=lo; k < hi; k++){
-                    output[k] =  value;
+                    output[k] += value;
             }
         }
     }
@@ -478,7 +478,6 @@ void bwGetOverlappingValuesCore(bigWigFile_t *fp, bwOverlapBlock_t *o, uint32_t 
     if(compressed && buf) free(buf);
     if(compBuf) free(compBuf);
     return;
-
 
 error:
     fprintf(stderr, "[bwGetOverlappingValuesCore] Got an error\n");

--- a/test/test.py
+++ b/test/test.py
@@ -72,3 +72,9 @@ except:
     p2 = Popen(["md5"], stdin=p1.stdout, stdout=PIPE)
 md5sum = p2.communicate()[0].strip().split()[0]
 assert(md5sum == "33ef99571bdaa8c9130149e99332b17b")
+
+
+p1 = Popen(["./test/testValues", "test/test.bw", "test/output2.bw"], stdout=PIPE)
+result = p1.communicate()[0].strip().split()[0].strip()
+assert result == "OK"
+

--- a/test/testFiles.c
+++ b/test/testFiles.c
@@ -1,0 +1,114 @@
+#include "bigWig.h"
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <math.h>
+#include <time.h>
+
+int almost_equal(float a, float b) {
+	return fabs(a - b) < 1e-8;
+}
+
+int main(int argc, char *argv[]) {
+    bigWigFile_t *afp = NULL;
+    bigWigFile_t *bfp = NULL;
+    if(argc != 4) {
+	// see if the values in 2 bigwig files are identical
+        fprintf(stderr, "Usage: %s a.bw b.bw chrom\n", argv[0]);
+        return 1;
+    }
+    char *chrom = argv[3];
+
+    afp = bwOpen(argv[1], NULL, "r");
+    if(!afp) {
+        fprintf(stderr, "An error occured while opening %s\n", argv[1]);
+        return 1;
+    }
+    bfp = bwOpen(argv[2], NULL, "r");
+    if(!bfp) {
+        fprintf(stderr, "An error occured while opening %s\n", argv[2]);
+        return 1;
+    }
+
+    uint32_t atid = bwGetTid(afp, chrom);
+    if(atid == UINT32_MAX) {
+	    fprintf(stderr, "chromosome: %s not found in %s\n", chrom, argv[1]);
+	    return 1;
+    }
+    uint32_t btid = bwGetTid(bfp, chrom);
+    if(btid == UINT32_MAX) {
+	    fprintf(stderr, "chromosome: %s not found in %s\n", chrom, argv[2]);
+	    return 1;
+    }
+    if (afp->cl->len[atid] != bfp->cl->len[btid]) {
+	    fprintf(stderr, "differing lenghts for chromosome %s. %d vs %d\n",
+		    chrom, afp->cl->len[atid], bfp->cl->len[btid]);
+	    return 1;
+    }
+    uint32_t i;
+    clock_t start = clock();
+    float* avalues = malloc(sizeof(float) * afp->cl->len[atid]);
+    for(i=0;i<afp->cl->len[atid];i++) { avalues[i] = 0; }
+    clock_t end = clock();
+    fprintf(stderr, "time to allocate: %.3f seconds\n", ((double) (end - start)) / CLOCKS_PER_SEC);
+
+
+    float* bvalues = malloc(sizeof(float) * bfp->cl->len[btid]);
+    for(i=0;i<bfp->cl->len[atid];i++) { bvalues[i] = 0; }
+    int ret = 0;
+
+     /*
+     it = bwOverlappingIntervalsIterator(bfp, chrom, 0, bfp->cl->len[btid], 10000);
+     while(it->data != NULL){
+       for(i=0;i<it->intervals->l;i++){
+	  for(p=it->intervals->start[i];p<it->intervals->end[i];p++){
+		  bvalues[p] = it->intervals->value[i];
+	  }
+       }
+       it = bwIteratorNext(it);
+     }
+     bwIteratorDestroy(it);
+     */
+    start = clock();
+    bwGetOverlappingValues(bfp, chrom, 0, bfp->cl->len[btid], 0, bvalues);
+    end = clock();
+    fprintf(stderr, "get values in %.3f seconds\n", ((double) (end - start)) / CLOCKS_PER_SEC);
+
+    start = clock();
+    bwOverlapIterator_t *it = bwOverlappingIntervalsIterator(afp, chrom, 0, afp->cl->len[atid], 10000);
+
+    uint32_t p;
+    while(it->data != NULL){
+      for(i=0;i<it->intervals->l;i++){
+	  for(p=it->intervals->start[i];p<it->intervals->end[i];p++){
+		  avalues[p] = it->intervals->value[i];
+	  }
+       }
+       it = bwIteratorNext(it);
+    }
+    bwIteratorDestroy(it);
+    end = clock();
+    fprintf(stderr, "iterator in %.3f seconds\n", ((double) (end - start)) / CLOCKS_PER_SEC);
+
+
+    for(i=0;i<afp->cl->len[atid];i++){
+	    if(avalues[i] != bvalues[i]) {
+		    fprintf(stderr, "different values at %d. %.2f vs %.2f\n", i, avalues[i], bvalues[i]);
+		    ret = 1;
+	    }
+    }
+
+
+    free(avalues);
+    free(bvalues);
+
+    //free(output);
+    bwClose(afp);
+    bwClose(bfp);
+    bwCleanup();
+    if(ret == 0) {
+    fprintf(stdout, "OK\n");
+    }
+    return ret;
+}

--- a/test/testValues.c
+++ b/test/testValues.c
@@ -1,0 +1,96 @@
+#include "bigWig.h"
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <math.h>
+
+int almost_equal(float a, float b) {
+	return fabs(a - b) < 1e-8;
+}
+
+int main(int argc, char *argv[]) {
+    bigWigFile_t *ifp = NULL;
+    bigWigFile_t *ofp = NULL;
+    if(argc != 3) {
+        fprintf(stderr, "Usage: %s {inputfile.bw|URL://path/inputfile.bw} outputfile.bw\n", argv[0]);
+        return 1;
+    }
+
+    if(bwInit(1<<17) != 0) {
+        fprintf(stderr, "Received an error in bwInit\n");
+        return 1;
+    }
+
+    ifp = bwOpen(argv[1], NULL, "r");
+    if(!ifp) {
+        fprintf(stderr, "An error occured while opening %s\n", argv[1]);
+        return 1;
+    }
+
+    ofp = bwOpen(argv[2], NULL, "w");
+    if(!ofp) {
+        bwClose(ifp);
+        fprintf(stderr, "An error occured while opening %s\n", argv[2]);
+        return 1;
+    }
+
+    if(bwCreateHdr(ofp, 10)) goto error; //ten zoom levels
+    ofp->cl = bwCreateChromList(ifp->cl->chrom, ifp->cl->len, ifp->cl->nKeys);
+    if(!ofp->cl) goto error;
+
+    if(bwWriteHdr(ofp)) goto error;
+    bwClose(ifp);
+
+    //Copy all of the intervals
+    char *chroms[] = {"1", "1", "1", "1"};
+
+    uint32_t starts[] = {100, 3000, 40004, 49001};
+    uint32_t stops[] =  {101, 3044, 40068, 50000};
+    float values[] = {10.1, 100.1, 1000.1, 5000.1};
+    bwAddIntervals(ofp, chroms, starts, stops, values, 4);
+    bwClose(ofp);
+
+
+    ifp = bwOpen(argv[2], NULL, "r");
+    if(!ifp) {
+        fprintf(stderr, "An error occured while opening for reading %s\n", argv[2]);
+        return 1;
+    }
+
+    float *output = malloc(sizeof(float)*50000);
+
+    bwGetOverlappingValues(ifp, "1", 0, 50000, 0.0, output);
+    int i;
+    for(i=0; i < 100;i++){
+        if(!almost_equal(output[i], 0.0)) { fprintf(stderr, "bad missing value at output[%d]: %.1f\n", i, output[i]); }
+    }
+    for(i=100; i < 101;i++){
+        if(!almost_equal(output[i], 10.1)) { fprintf(stderr, "bad float value at output[%d]: %.1f\n", i, output[i]); }
+    }
+    for(i=3000; i < 3044;i++){
+        if(!almost_equal(output[i], 100.1)) { fprintf(stderr, "bad float value at output[%d]: %.1f\n", i, output[i]); }
+    }
+    for(i=40004; i < 40068;i++){
+        if(!almost_equal(output[i], 1000.1)) { fprintf(stderr, "bad float value at output[%d]: %.1f\n", i, output[i]); }
+    }
+    for(i=49001; i < 50000;i++){
+        if(!almost_equal(output[i], 5000.1)) { fprintf(stderr, "bad float value at output[%d]: %.1f\n", i, output[i]); }
+    }
+
+    //fprintf(stderr, "output[3011] should be 100.1 %.1f\n", output[3011]);
+
+    free(output);
+    bwClose(ifp);
+    bwCleanup();
+    fprintf(stdout, "OK\n");
+
+    return 0;
+
+error:
+    fprintf(stderr, "Got an error somewhere!\n");
+    bwClose(ifp);
+    bwClose(ofp);
+    bwCleanup();
+    return 1;
+}

--- a/test/testValues.c
+++ b/test/testValues.c
@@ -49,6 +49,11 @@ int main(int argc, char *argv[]) {
     uint32_t stops[] =  {101, 3044, 40068, 50000};
     float values[] = {10.1, 100.1, 1000.1, 5000.1};
     bwAddIntervals(ofp, chroms, starts, stops, values, 4);
+
+    bwAddIntervalSpanSteps(ofp, "1", 60000, 100, 100, values, 4);
+    starts[0] = 70000; starts[1] = 70001; starts[2] = 70002; starts[3] = 70003;
+    bwAddIntervalSpans(ofp, "1", starts, 1, values, 4);
+
     bwClose(ofp);
 
 
@@ -57,28 +62,45 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "An error occured while opening for reading %s\n", argv[2]);
         return 1;
     }
+    int L = 100000;
 
-    float *output = malloc(sizeof(float)*50000);
+    float *output = malloc(sizeof(float)*L);
 
-    bwGetOverlappingValues(ifp, "1", 0, 50000, 0.0, output);
+    bwGetOverlappingValues(ifp, "1", 0, L, 0.0, output);
     int i;
     for(i=0; i < 100;i++){
-        if(!almost_equal(output[i], 0.0)) { fprintf(stderr, "bad missing value at output[%d]: %.1f\n", i, output[i]); }
+        if(!almost_equal(output[i], 0.0)) { fprintf(stdout, "bad missing value at output[%d]: %.1f\n", i, output[i]); }
     }
     for(i=100; i < 101;i++){
-        if(!almost_equal(output[i], 10.1)) { fprintf(stderr, "bad float value at output[%d]: %.1f\n", i, output[i]); }
+        if(!almost_equal(output[i], 10.1)) { fprintf(stdout, "bad float value at output[%d]: %.1f\n", i, output[i]); }
     }
     for(i=3000; i < 3044;i++){
-        if(!almost_equal(output[i], 100.1)) { fprintf(stderr, "bad float value at output[%d]: %.1f\n", i, output[i]); }
+        if(!almost_equal(output[i], 100.1)) { fprintf(stdout, "bad float value at output[%d]: %.1f\n", i, output[i]); }
     }
     for(i=40004; i < 40068;i++){
-        if(!almost_equal(output[i], 1000.1)) { fprintf(stderr, "bad float value at output[%d]: %.1f\n", i, output[i]); }
+        if(!almost_equal(output[i], 1000.1)) { fprintf(stdout, "bad float value at output[%d]: %.1f\n", i, output[i]); }
     }
     for(i=49001; i < 50000;i++){
-        if(!almost_equal(output[i], 5000.1)) { fprintf(stderr, "bad float value at output[%d]: %.1f\n", i, output[i]); }
+        if(!almost_equal(output[i], 5000.1)) { fprintf(stdout, "bad float value at output[%d]: %.1f\n", i, output[i]); }
     }
-
-    //fprintf(stderr, "output[3011] should be 100.1 %.1f\n", output[3011]);
+    // span steps
+    for(i=60000; i < 60100;i++){
+        if(!almost_equal(output[i], 10.1)) { fprintf(stdout, "span step: bad float value at output[%d]: %.1f\n", i, output[i]); }
+    }
+    for(i=60100; i < 60200;i++){
+        if(!almost_equal(output[i], 100.1)) { fprintf(stdout, "span step: bad float value at output[%d]: %.1f\n", i, output[i]); }
+    }
+    for(i=60200; i < 60300;i++){
+        if(!almost_equal(output[i], 1000.1)) { fprintf(stdout, "span step: bad float value at output[%d]: %.1f\n", i, output[i]); }
+    }
+    for(i=60300; i < 60400;i++){
+        if(!almost_equal(output[i], 5000.1)) { fprintf(stdout, "span step: bad float value at output[%d]: %.1f\n", i, output[i]); }
+    }
+    // spans
+    if(!almost_equal(output[70000], 10.1)) { fprintf(stdout, "span: bad float value at output[%d]: %.1f\n", 7000, output[7000]); }
+    if(!almost_equal(output[70001], 100.1)) { fprintf(stdout, "span: bad float value at output[%d]: %.1f\n", 7001, output[7001]); }
+    if(!almost_equal(output[70002], 1000.1)) { fprintf(stdout, "span: bad float value at output[%d]: %.1f\n", 7002, output[7002]); }
+    if(!almost_equal(output[70003], 5000.1)) { fprintf(stdout, "span: bad float value at output[%d]: %.1f\n", 7003, output[7003]); }
 
     free(output);
     bwClose(ifp);
@@ -88,7 +110,7 @@ int main(int argc, char *argv[]) {
     return 0;
 
 error:
-    fprintf(stderr, "Got an error somewhere!\n");
+    fprintf(stdout, "Got an error somewhere!\n");
     bwClose(ifp);
     bwClose(ofp);
     bwCleanup();


### PR DESCRIPTION
this is an attempt to provide a fast-path for getting values that does not allocate and only fills an existing `float *`.

On my test-case (per-base WGS coverage output), this changes the run-time from 4.6 seconds to 3.6 seconds to get all of chromosome 1. That's not as large as I'd hoped and there's a lot of code duplication but I am posting for feedback. The actual speed improvement may be larger in real programs because it allows re-using the same memory. I think the rest of the time is spent in zlib decompression.