### PR TITLE
fix NOCURL build w/ gcc-4.4.7

### DIFF
--- a/bigWig.h
+++ b/bigWig.h
@@ -63,8 +63,11 @@ extern "C" {
  */
 #ifdef NOCURL
 #define LIBBIGWIG_CURL 0
+#ifndef CURLTYPE_DEFINED
+#define CURLTYPE_DEFINED
 typedef int CURLcode;
 typedef void CURL;
+#endif
 #else
 #define LIBBIGWIG_CURL 1
 #endif

--- a/bigWigIO.h
+++ b/bigWigIO.h
@@ -5,8 +5,11 @@
 #include <curl/curl.h>
 #else
 #include <stdio.h>
+#ifndef CURLTYPE_DEFINED
+#define CURLTYPE_DEFINED
 typedef int CURLcode;
 typedef void CURL;
+#endif
 #define CURLE_OK 0
 #define CURLE_FAILED_INIT 1
 #endif


### PR DESCRIPTION
Old gcc does not allow a type defined multiple times, which makes `-DNOCURL` build failing. Fixed it by putting ifdef guard around the typedefs.

```
20-03-04::16:53:31 [k04] ~/dl/libBigWig [master] % make clean && make CFLAGS="-DNOCURL"
rm -f *.o libBigWig.a libBigWig.so *.pico test/testLocal test/testRemote test/testWrite test/exampleWrite test/testRemoteManyContigs test/testBigBed test/testIterator example_output.bw
cc -I. -DNOCURL  -c -o io.o io.c
cc -I. -DNOCURL  -c -o bwValues.o bwValues.c
In file included from bwValues.c:1:
bigWig.h:66: error: redefinition of typedef ‘CURLcode’
bigWigIO.h:8: note: previous declaration of ‘CURLcode’ was here
bigWig.h:67: error: redefinition of typedef ‘CURL’
bigWigIO.h:9: note: previous declaration of ‘CURL’ was here
make: *** [bwValues.o] Error 1
20-03-04::16:53:34 [k04] ~/dl/libBigWig [master] % git checkout fix-nocurl
Switched to branch 'fix-nocurl'
20-03-04::16:53:39 [k04] ~/dl/libBigWig [fix-nocurl] % make clean && make CFLAGS="-DNOCURL"
rm -f *.o libBigWig.a libBigWig.so *.pico test/testLocal test/testRemote test/testWrite test/exampleWrite test/testRemoteManyContigs test/testBigBed test/testIterator example_output.bw
cc -I. -DNOCURL  -c -o io.o io.c
cc -I. -DNOCURL  -c -o bwValues.o bwValues.c
cc -I. -DNOCURL  -c -o bwRead.o bwRead.c
cc -I. -DNOCURL  -c -o bwStats.o bwStats.c
cc -I. -DNOCURL  -c -o bwWrite.o bwWrite.c
ar -rcs libBigWig.a io.o bwValues.o bwRead.o bwStats.o bwWrite.o
ranlib libBigWig.a
cc -I. -DNOCURL  -fpic -c -o io.pico io.c
cc -I. -DNOCURL  -fpic -c -o bwValues.pico bwValues.c
cc -I. -DNOCURL  -fpic -c -o bwRead.pico bwRead.c
cc -I. -DNOCURL  -fpic -c -o bwStats.pico bwStats.c
cc -I. -DNOCURL  -fpic -c -o bwWrite.pico bwWrite.c
cc -shared  -o libBigWig.so io.pico bwValues.pico bwRead.pico bwStats.pico bwWrite.pico  -lcurl -lm -lz
20-03-04::16:53:41 [k04] ~/dl/libBigWig [fix-nocurl] %
```
