### PR TITLE
Contribute CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(libBigWig LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+option(WITH_CURL "Enable CURL support" ON)
+option(WITH_ZLIBNG "Link to zlib-ng instead of zlib" OFF)
+option(BUILD_SHARED_LIBS "Build shared library" OFF)
+option(ENABLE_TESTING "Build tests" OFF)
+
+if(WITH_ZLIBNG)
+  find_package(zlib-ng REQUIRED)
+else()
+  find_package(ZLIB REQUIRED)
+endif()
+
+if(WITH_CURL)
+  find_package(CURL REQUIRED)
+endif()
+
+add_library(BigWig)
+add_library(libBigWig::libbigwig ALIAS BigWig)
+
+target_sources(
+  BigWig
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bwRead.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/bwStats.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/bwValues.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/bwWrite.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/io.c)
+
+target_include_directories(BigWig PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(NOT WITH_CURL)
+  target_compile_definitions(BigWig PUBLIC NOCURL)
+endif()
+
+target_link_libraries(
+  BigWig PUBLIC $<IF:$<BOOL:${WITH_ZLIBNG}>,zlib-ng::zlib-ng,ZLIB::ZLIB>
+                $<$<BOOL:${WITH_CURL}>:CURL::libcurl> m)
+
+target_compile_features(BigWig PRIVATE c_std_${CMAKE_C_STANDARD})
+
+set(LIBBIGWIG_COMPILER_WARNINGS -Wall -Wsign-compare)
+target_compile_options(BigWig PRIVATE ${LIBBIGWIG_COMPILER_WARNINGS})
+
+set(LIBBIGWIG_PUBLIC_HEADERS "bigWig.h;bigWigIO.h;bwCommon.h;bwValues.h")
+
+set_target_properties(BigWig PROPERTIES PUBLIC_HEADER
+                                        "${LIBBIGWIG_PUBLIC_HEADERS}")
+
+if(ENABLE_TESTING)
+  add_subdirectory(test)
+endif()
+
+include(GNUInstallDirs)
+install(
+  TARGETS BigWig
+  BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libbigwig)

--- a/README.md
+++ b/README.md
@@ -246,3 +246,5 @@ There are currently two python interfaces that make use of libBigWig: [pyBigWig]
 # Building without remote file access
 
 If you want to compile without remote file access (e.g., you don't have curl installed), then you can append `-DNOCURL` to the `CFLAGS` line in the `Makefile`. You will also need to remove `-lcurl` from the `LIBS` line.
+
+If you are building libBigWig using CMake you can instead pass `-DWITH_CURL=OFF` when calling CMake at configuration time.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+set(LOCAL_TEST_TARGETS "exampleWrite;testBigBed;testIterator;testLocal;testWrite")
+
+set(REMOTE_TEST_TARGETS "testRemote;testRemoteManyContigs")
+
+if (WITH_CURL)
+  set(TEST_TARGETS "${LOCAL_TEST_TARGETS};${REMOTE_TEST_TARGETS}")
+else()
+  set(TEST_TARGETS "${LOCAL_TEST_TARGETS}")
+endif()
+
+set(LIBBIGWIG_COMPILER_WARNINGS -Wall -Wsign-compare)
+
+foreach(TEST_TARGET ${TEST_TARGETS})
+  add_executable(${TEST_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_TARGET}.c)
+  target_link_libraries(${TEST_TARGET} PUBLIC ${CONAN_LIBS}
+                                              libBigWig::libbigwig)
+  target_compile_features(${TEST_TARGET} PRIVATE c_std_${CMAKE_C_STANDARD})
+  target_compile_options(${TEST_TARGET} PRIVATE ${LIBBIGWIG_COMPILER_WARNINGS})
+endforeach()


### PR DESCRIPTION
This PR adds two CMakeLists.txt files so that library and tests can be built using CMake.

I am trying to package libBigWig for [Conan](https://conan.io/center), and the simplest way to do so is using CMake.

If you'd rather not support CMake as build system, libBigWig can still be packaged with Conan.
In this case I would contribute CMake build scripts together with a conan recipe when submitting the package to [conan-io/conan-center-index](https://github.com/conan-io/conan-center-index).