### PR TITLE
Fix potential memory leak in bwWriteHdr

### DIFF
--- a/bwWrite.c
+++ b/bwWrite.c
@@ -188,7 +188,8 @@ int bwWriteHdr(bigWigFile_t *bw) {
     uint32_t magic = BIGWIG_MAGIC;
     uint16_t two = 4;
     FILE *fp;
-    void *p = calloc(58, sizeof(uint8_t)); //58 bytes of nothing
+    const uint8_t pbuff[58] = {0}; // 58 bytes of nothing
+    const void *p = (const void *)&pbuff;
     if(!bw->isWrite) return 1;
 
     //The header itself, largely just reserving space...
@@ -223,7 +224,6 @@ int bwWriteHdr(bigWigFile_t *bw) {
     //Save space for the number of blocks
     if(fwrite(p, sizeof(uint8_t), 8, fp) != 8) return 13;
 
-    free(p);
     return 0;
 }
 


### PR DESCRIPTION
Every time bwWriteHdr is called 58 bytes will be leaked if the function returns early because of one of the check between line 191 and 226.