### PR TITLE
Replace calls to strdup with calls to bwStrdup

### DIFF
--- a/bwCommon.h
+++ b/bwCommon.h
@@ -68,3 +68,7 @@ void destroyBWOverlapBlock(bwOverlapBlock_t *b);
  * @return 0 on success
  */
 int bwFinalize(bigWigFile_t *fp);
+
+/// @cond SKIP
+char *bwStrdup(const char *s);
+/// @endcond

--- a/bwRead.c
+++ b/bwRead.c
@@ -194,7 +194,7 @@ static uint64_t readChromLeaf(bigWigFile_t *bw, chromList_t *cl, uint32_t valueS
         if(bwRead((void*) chrom, sizeof(char), valueSize, bw) != valueSize) goto error;
         if(bwRead((void*) &idx, sizeof(uint32_t), 1, bw) != 1) goto error;
         if(bwRead((void*) &(cl->len[idx]), sizeof(uint32_t), 1, bw) != 1) goto error;
-        cl->chrom[idx] = strdup(chrom);
+        cl->chrom[idx] = bwStrdup(chrom);
         if(!(cl->chrom[idx])) goto error;
     }
 
@@ -424,4 +424,15 @@ bigWigFile_t *bbOpen(char *fname, CURLcode (*callBack) (CURL*)) {
 error:
     bwClose(bb);
     return NULL;
+}
+
+
+//Implementation taken from musl:
+//https://git.musl-libc.org/cgit/musl/tree/src/string/strdup.c
+//License: https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT
+char* bwStrdup(const char *s) {
+	size_t l = strlen(s);
+	char *d = malloc(l+1);
+	if (!d) return NULL;
+	return memcpy(d, s, l+1);
 }

--- a/bwValues.c
+++ b/bwValues.c
@@ -379,7 +379,7 @@ static bbOverlappingEntries_t *pushBBIntervals(bbOverlappingEntries_t *o, uint32
     }
     o->start[o->l] = start;
     o->end[o->l] = end;
-    if(withString) o->str[o->l] = strdup(str);
+    if(withString) o->str[o->l] = bwStrdup(str);
     o->l++;
     return o;
 

--- a/bwWrite.c
+++ b/bwWrite.c
@@ -32,7 +32,7 @@ chromList_t *bwCreateChromList(char **chroms, uint32_t *lengths, int64_t n) {
 
     for(i=0; i<n; i++) {
         cl->len[i] = lengths[i];
-        cl->chrom[i] = strdup(chroms[i]);
+        cl->chrom[i] = bwStrdup(chroms[i]);
         if(!cl->chrom[i]) goto error;
     }
 


### PR DESCRIPTION
This PR implements a workaround for segfaults due to calls to `strdup`, which is not part of ANSI C.

This is usually not an issue when compiling libBigWig without specifying a C standard and linking with common libc implementation.

However, when passing `-std=c99` to GCC, the `__STRICT_ANSI__` macro is defined, which causes all non standard declarations to disappear from libc headers.

On my machine with (gcc v12.1.1), the code still compiles, but the following warning is issued:
```
warning: implicit declaration of function ‘strdup’
```

Applications calling libBigWig functions involving `strdup` (usually) segfault at runtime.

See [this](https://stackoverflow.com/a/26284172) SO post for more details.

This PR replaces calls to `strdup` with `bwStrdup`.

`bwStrdup` implementation is copied verbatim from [musl strdup](https://git.musl-libc.org/cgit/musl/tree/src/string/strdup.c) (MIT license).

Another workaround for this issue could be to add `extern char* strdup(const char*);` to e.g. `bigWig.h`.
This should work as long libBigWig is linked with a libc implementation that actually provides `strdup`.