### PR TITLE
Improve const-correctness of public API

### DIFF
--- a/bigWig.h
+++ b/bigWig.h
@@ -314,10 +314,10 @@ bigWigFile_t *bbOpen(const char *fname, CURLcode (*callBack)(CURL*));
  * The "auto SQL" field contains the names and value types of the entries in
  * each bigBed entry. If you need to parse a particular value out of each entry,
  * then you'll need to first parse this.
- * @param bw The file pointer to a valid bigWigFile_t
+ * @param fp The file pointer to a valid bigWigFile_t
  * @return A char *, which you MUST free!
  */
-char *bbGetSQL(bigWigFile_t *bw);
+char *bbGetSQL(bigWigFile_t *fp);
 
 /*!
  * @brief Closes a bigWigFile_t and frees up allocated memory
@@ -387,7 +387,7 @@ bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, const char *ch
  * @brief Creates an iterator over intervals in a bigWig file
  * Iterators can be traversed with `bwIteratorNext()` and destroyed with `bwIteratorDestroy()`.
  * Intervals are in the `intervals` member and `data` can be used to determine when to end iteration.
- * @param bw A valid bigWigFile_t pointer. This MUST be for a bigWig file!
+ * @param fp A valid bigWigFile_t pointer. This MUST be for a bigWig file!
  * @param chrom A valid chromosome name.
  * @param start The start position of the interval. This is 0-based half open, so 0 is the first base.
  * @param end The end position of the interval. Again, this is 0-based half open, so 100 will include the 100th base...which is at position 99.
@@ -397,13 +397,13 @@ bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, const char *ch
  * @see bwIteratorNext
  * @see bwIteratorDestroy
  */ 
-bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, uint32_t blocksPerIteration);
+bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, uint32_t blocksPerIteration);
 
 /*!
  * @brief Creates an iterator over entries in a bigBed file
  * Iterators can be traversed with `bwIteratorNext()` and destroyed with `bwIteratorDestroy()`.
  * Entries are in the `entries` member and `data` can be used to determine when to end iteration.
- * @param bw A valid bigWigFile_t pointer. This MUST be for a bigBed file!
+ * @param fp A valid bigWigFile_t pointer. This MUST be for a bigBed file!
  * @param chrom A valid chromosome name.
  * @param start The start position of the interval. This is 0-based half open, so 0 is the first base.
  * @param end The end position of the interval. Again, this is 0-based half open, so 100 will include the 100th base...which is at position 99.
@@ -415,7 +415,7 @@ bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, const char
  * @see bwIteratorNext
  * @see bwIteratorDestroy
  */ 
-bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, int withString, uint32_t blocksPerIteration);
+bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, int withString, uint32_t blocksPerIteration);
 
 /*!
  * @brief Traverses to the entries/intervals in the next group of blocks.
@@ -435,7 +435,7 @@ void bwIteratorDestroy(bwOverlapIterator_t *iter);
 /*!
  * @brief Return all per-base bigWig values in a given interval.
  * Given an interval (e.g., chr1:0-100), return the value at each position in a bigWig file. Positions without associated values are suppressed by default, but may be returned if `includeNA` is not 0.
- * @param bw A valid bigWigFile_t pointer.
+ * @param fp A valid bigWigFile_t pointer.
  * @param chrom A valid chromosome name.
  * @param start The start position of the interval. This is 0-based half open, so 0 is the first base.
  * @param end The end position of the interval. Again, this is 0-based half open, so 100 will include the 100th base...which is at position 99.
@@ -445,7 +445,7 @@ void bwIteratorDestroy(bwOverlapIterator_t *iter);
  * @see bwDestroyOverlappingIntervals
  * @see bwGetOverlappingIntervals
  */
-bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, int includeNA);
+bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, int includeNA);
 
 /*!
  * @brief Determines per-interval bigWig statistics

--- a/bigWig.h
+++ b/bigWig.h
@@ -279,7 +279,7 @@ void bwCleanup(void);
  * @param callBack An optional user-supplied function. This is applied to remote connections so users can specify things like proxy and password information. See `test/testRemote` for an example.
  * @return 1 if the file appears to be bigWig, otherwise 0.
  */
-int bwIsBigWig(char *fname, CURLcode (*callBack)(CURL*));
+int bwIsBigWig(const char *fname, CURLcode (*callBack)(CURL*));
 
 /*!
  * @brief Determine is a file is a bigBed file.
@@ -288,7 +288,7 @@ int bwIsBigWig(char *fname, CURLcode (*callBack)(CURL*));
  * @param callBack An optional user-supplied function. This is applied to remote connections so users can specify things like proxy and password information. See `test/testRemote` for an example.
  * @return 1 if the file appears to be bigWig, otherwise 0.
  */
-int bbIsBigBed(char *fname, CURLcode (*callBack)(CURL*));
+int bbIsBigBed(const char *fname, CURLcode (*callBack)(CURL*));
 
 /*!
  * @brief Opens a local or remote bigWig file.
@@ -298,7 +298,7 @@ int bbIsBigBed(char *fname, CURLcode (*callBack)(CURL*));
  * @param mode The mode, by default "r". Both local and remote files can be read, but only local files can be written. For files being written the callback function is ignored. If and only if the mode contains "w" will the file be opened for writing (in all other cases the file will be opened for reading.
  * @return A bigWigFile_t * on success and NULL on error.
  */
-bigWigFile_t *bwOpen(char *fname, CURLcode (*callBack)(CURL*), const char* mode);
+bigWigFile_t *bwOpen(const char *fname, CURLcode (*callBack)(CURL*), const char* mode);
 
 /*!
  * @brief Opens a local or remote bigBed file.
@@ -307,17 +307,17 @@ bigWigFile_t *bwOpen(char *fname, CURLcode (*callBack)(CURL*), const char* mode)
  * @param callBack An optional user-supplied function. This is applied to remote connections so users can specify things like proxy and password information. See `test/testRemote` for an example.
  * @return A bigWigFile_t * on success and NULL on error.
  */
-bigWigFile_t *bbOpen(char *fname, CURLcode (*callBack)(CURL*));
+bigWigFile_t *bbOpen(const char *fname, CURLcode (*callBack)(CURL*));
 
 /*!
  * @brief Returns a string containing the SQL entry (or NULL).
  * The "auto SQL" field contains the names and value types of the entries in
  * each bigBed entry. If you need to parse a particular value out of each entry,
  * then you'll need to first parse this.
- * @param fp The file pointer to a valid bigWigFile_t
+ * @param bw The file pointer to a valid bigWigFile_t
  * @return A char *, which you MUST free!
  */
-char *bbGetSQL(bigWigFile_t *fp);
+char *bbGetSQL(bigWigFile_t *bw);
 
 /*!
  * @brief Closes a bigWigFile_t and frees up allocated memory
@@ -339,7 +339,7 @@ void bwClose(bigWigFile_t *fp);
  * @param chrom A chromosome name
  * @return An ID, -1 will be returned on error (note that this is an unsigned value, so that's ~4 billion. bigWig/bigBed files can't store that many chromosomes anyway.
  */
-uint32_t bwGetTid(bigWigFile_t *fp, char *chrom);
+uint32_t bwGetTid(const bigWigFile_t *fp, const char *chrom);
 
 /*!
  * @brief Frees space allocated by `bwGetOverlappingIntervals`
@@ -367,7 +367,7 @@ void bbDestroyOverlappingEntries(bbOverlappingEntries_t *o);
  * @see bwDestroyOverlappingIntervals
  * @see bwGetValues
  */
-bwOverlappingIntervals_t *bwGetOverlappingIntervals(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end);
+bwOverlappingIntervals_t *bwGetOverlappingIntervals(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end);
 
 /*!
  * @brief Return bigBed entries overlapping an interval.
@@ -381,13 +381,13 @@ bwOverlappingIntervals_t *bwGetOverlappingIntervals(bigWigFile_t *fp, char *chro
  * @see bbOverlappingEntries_t
  * @see bbDestroyOverlappingEntries
  */
-bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int withString);
+bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, int withString);
 
 /*!
  * @brief Creates an iterator over intervals in a bigWig file
  * Iterators can be traversed with `bwIteratorNext()` and destroyed with `bwIteratorDestroy()`.
  * Intervals are in the `intervals` member and `data` can be used to determine when to end iteration.
- * @param fp A valid bigWigFile_t pointer. This MUST be for a bigWig file!
+ * @param bw A valid bigWigFile_t pointer. This MUST be for a bigWig file!
  * @param chrom A valid chromosome name.
  * @param start The start position of the interval. This is 0-based half open, so 0 is the first base.
  * @param end The end position of the interval. Again, this is 0-based half open, so 100 will include the 100th base...which is at position 99.
@@ -397,13 +397,13 @@ bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, char *chrom, u
  * @see bwIteratorNext
  * @see bwIteratorDestroy
  */ 
-bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, uint32_t blocksPerIteration);
+bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, uint32_t blocksPerIteration);
 
 /*!
  * @brief Creates an iterator over entries in a bigBed file
  * Iterators can be traversed with `bwIteratorNext()` and destroyed with `bwIteratorDestroy()`.
  * Entries are in the `entries` member and `data` can be used to determine when to end iteration.
- * @param fp A valid bigWigFile_t pointer. This MUST be for a bigBed file!
+ * @param bw A valid bigWigFile_t pointer. This MUST be for a bigBed file!
  * @param chrom A valid chromosome name.
  * @param start The start position of the interval. This is 0-based half open, so 0 is the first base.
  * @param end The end position of the interval. Again, this is 0-based half open, so 100 will include the 100th base...which is at position 99.
@@ -415,7 +415,7 @@ bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *fp, char *chro
  * @see bwIteratorNext
  * @see bwIteratorDestroy
  */ 
-bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int withString, uint32_t blocksPerIteration);
+bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, int withString, uint32_t blocksPerIteration);
 
 /*!
  * @brief Traverses to the entries/intervals in the next group of blocks.
@@ -435,7 +435,7 @@ void bwIteratorDestroy(bwOverlapIterator_t *iter);
 /*!
  * @brief Return all per-base bigWig values in a given interval.
  * Given an interval (e.g., chr1:0-100), return the value at each position in a bigWig file. Positions without associated values are suppressed by default, but may be returned if `includeNA` is not 0.
- * @param fp A valid bigWigFile_t pointer.
+ * @param bw A valid bigWigFile_t pointer.
  * @param chrom A valid chromosome name.
  * @param start The start position of the interval. This is 0-based half open, so 0 is the first base.
  * @param end The end position of the interval. Again, this is 0-based half open, so 100 will include the 100th base...which is at position 99.
@@ -445,7 +445,7 @@ void bwIteratorDestroy(bwOverlapIterator_t *iter);
  * @see bwDestroyOverlappingIntervals
  * @see bwGetOverlappingIntervals
  */
-bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int includeNA);
+bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, int includeNA);
 
 /*!
  * @brief Determines per-interval bigWig statistics
@@ -459,7 +459,7 @@ bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, char *chrom, uint32_t st
  * @see bwStatsType
  * @return A pointer to an array of double precission floating point values. Note that bigWig files only hold 32-bit values, so this is done to help prevent overflows.
  */
-double *bwStats(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type);
+double *bwStats(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type);
 
 /*!
  * @brief Determines per-interval bigWig statistics
@@ -473,7 +473,7 @@ double *bwStats(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, uin
  * @see bwStatsType
  * @return A pointer to an array of double precission floating point values. Note that bigWig files only hold 32-bit values, so this is done to help prevent overflows.
 */
-double *bwStatsFromFull(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type);
+double *bwStatsFromFull(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type);
 
 //Writer functions
 
@@ -494,7 +494,7 @@ int bwCreateHdr(bigWigFile_t *fp, int32_t maxZooms);
  * @param n The number of chromosomes (thus, the length of `chroms` and `lengths`)
  * @return A pointer to a chromList_t or NULL on error.
  */
-chromList_t *bwCreateChromList(char **chroms, uint32_t *lengths, int64_t n);
+chromList_t *bwCreateChromList(const char* const* chroms, const uint32_t *lengths, int64_t n);
 
 /*!
  * @brief Write a the header to a bigWig file.
@@ -521,7 +521,7 @@ int bwWriteHdr(bigWigFile_t *bw);
  * @return 0 on success and another value on error.
  * @see bwAppendIntervals
  */
-int bwAddIntervals(bigWigFile_t *fp, char **chrom, uint32_t *start, uint32_t *end, float *values, uint32_t n);
+int bwAddIntervals(bigWigFile_t *fp, const char* const* chrom, const uint32_t *start, const uint32_t *end, const float *values, uint32_t n);
 
 /*!
  * @brief Append bedGraph-like intervals to a previous block of bedGraph-like intervals in a bigWig file.
@@ -535,7 +535,7 @@ int bwAddIntervals(bigWigFile_t *fp, char **chrom, uint32_t *start, uint32_t *en
  * @warning Do NOT use this after `bwAddIntervalSpanSteps()`, `bwAppendIntervalSpanSteps()`, `bwAddIntervalSpanSteps()`, or `bwAppendIntervalSpanSteps()`.
  * @see bwAddIntervals
  */
-int bwAppendIntervals(bigWigFile_t *fp, uint32_t *start, uint32_t *end, float *values, uint32_t n);
+int bwAppendIntervals(bigWigFile_t *fp, const uint32_t *start, const uint32_t *end, const float *values, uint32_t n);
 
 /*!
  * @brief Add a new block of variable-step entries to a bigWig file
@@ -553,7 +553,7 @@ int bwAppendIntervals(bigWigFile_t *fp, uint32_t *start, uint32_t *end, float *v
  * @return 0 on success and another value on error.
  * @see bwAppendIntervalSpans
  */
-int bwAddIntervalSpans(bigWigFile_t *fp, char *chrom, uint32_t *start, uint32_t span, float *values, uint32_t n);
+int bwAddIntervalSpans(bigWigFile_t *fp, const char *chrom, const uint32_t *start, uint32_t span, const float *values, uint32_t n);
 
 /*!
  * @brief Append to a previous block of variable-step entries.
@@ -566,7 +566,7 @@ int bwAddIntervalSpans(bigWigFile_t *fp, char *chrom, uint32_t *start, uint32_t 
  * @warning Do NOT use this after `bwAddIntervals()`, `bwAppendIntervals()`, `bwAddIntervalSpanSteps()` or `bwAppendIntervalSpanSteps()`
  * @see bwAddIntervalSpans
  */
-int bwAppendIntervalSpans(bigWigFile_t *fp, uint32_t *start, float *values, uint32_t n);
+int bwAppendIntervalSpans(bigWigFile_t *fp, const uint32_t *start, const float *values, uint32_t n);
 
 /*!
  * @brief Add a new block of fixed-step entries to a bigWig file
@@ -585,7 +585,7 @@ int bwAppendIntervalSpans(bigWigFile_t *fp, uint32_t *start, float *values, uint
  * @return 0 on success and another value on error.
  * @see bwAddIntervalSpanSteps
  */
-int bwAddIntervalSpanSteps(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t span, uint32_t step, float *values, uint32_t n);
+int bwAddIntervalSpanSteps(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t span, uint32_t step, const float *values, uint32_t n);
 
 /*!
  * @brief Append to a previous block of fixed-step entries.
@@ -597,7 +597,7 @@ int bwAddIntervalSpanSteps(bigWigFile_t *fp, char *chrom, uint32_t start, uint32
  * @warning Do NOT use this after `bwAddIntervals()`, `bwAppendIntervals()`, `bwAddIntervalSpans()` or `bwAppendIntervalSpans()`
  * @see bwAddIntervalSpanSteps
  */
-int bwAppendIntervalSpanSteps(bigWigFile_t *fp, float *values, uint32_t n);
+int bwAppendIntervalSpanSteps(bigWigFile_t *fp, const float *values, uint32_t n);
 
 #ifdef __cplusplus
 }

--- a/bigWigIO.h
+++ b/bigWigIO.h
@@ -49,7 +49,7 @@ typedef struct {
     size_t bufLen; /**<The actual size of the buffer used.*/
     enum bigWigFile_type_enum type; /**<The connection type*/
     int isCompressed; /**<1 if the file is compressed, otherwise 0*/
-    char *fname; /**<Only needed for remote connections. The original URL/filename requested, since we need to make multiple connections.*/
+    const char *fname; /**<Only needed for remote connections. The original URL/filename requested, since we need to make multiple connections.*/
 } URL_t;
 
 /*!
@@ -94,7 +94,7 @@ CURLcode urlSeek(URL_t *URL, size_t pos);
  *
  *  @return A URL_t * or NULL on error.
  */
-URL_t *urlOpen(char *fname, CURLcode (*callBack)(CURL*), const char* mode);
+URL_t *urlOpen(const char *fname, CURLcode (*callBack)(CURL*), const char* mode);
 
 /*!
  *  @brief Close a local/remote file

--- a/bwRead.c
+++ b/bwRead.c
@@ -299,7 +299,7 @@ void bwClose(bigWigFile_t *fp) {
     free(fp);
 }
 
-int bwIsBigWig(char *fname, CURLcode (*callBack) (CURL*)) {
+int bwIsBigWig(const char *fname, CURLcode (*callBack) (CURL*)) {
     uint32_t magic = 0;
     URL_t *URL = NULL;
 
@@ -329,7 +329,7 @@ error:
     return NULL;
 }
 
-int bbIsBigBed(char *fname, CURLcode (*callBack) (CURL*)) {
+int bbIsBigBed(const char *fname, CURLcode (*callBack) (CURL*)) {
     uint32_t magic = 0;
     URL_t *URL = NULL;
 
@@ -342,7 +342,7 @@ int bbIsBigBed(char *fname, CURLcode (*callBack) (CURL*)) {
     return 0;
 }
 
-bigWigFile_t *bwOpen(char *fname, CURLcode (*callBack) (CURL*), const char *mode) {
+bigWigFile_t *bwOpen(const char *fname, CURLcode (*callBack) (CURL*), const char *mode) {
     bigWigFile_t *bwg = calloc(1, sizeof(bigWigFile_t));
     if(!bwg) {
         fprintf(stderr, "[bwOpen] Couldn't allocate space to create the output object!\n");
@@ -394,7 +394,7 @@ error:
     return NULL;
 }
 
-bigWigFile_t *bbOpen(char *fname, CURLcode (*callBack) (CURL*)) {
+bigWigFile_t *bbOpen(const char *fname, CURLcode (*callBack) (CURL*)) {
     bigWigFile_t *bb = calloc(1, sizeof(bigWigFile_t));
     if(!bb) {
         fprintf(stderr, "[bbOpen] Couldn't allocate space to create the output object!\n");

--- a/bwRead.c
+++ b/bwRead.c
@@ -312,15 +312,15 @@ int bwIsBigWig(const char *fname, CURLcode (*callBack) (CURL*)) {
     return 0;
 }
 
-char *bbGetSQL(bigWigFile_t *bw) {
+char *bbGetSQL(bigWigFile_t *fp) {
     char *o = NULL;
     uint64_t len;
-    if(!bw->hdr->sqlOffset) return NULL;
-    len = bw->hdr->summaryOffset - bw->hdr->sqlOffset; //This includes the NULL terminator
+    if(!fp->hdr->sqlOffset) return NULL;
+    len = fp->hdr->summaryOffset - fp->hdr->sqlOffset; //This includes the NULL terminator
     o = malloc(sizeof(char) * len);
     if(!o) goto error;
-    if(bwSetPos(bw, bw->hdr->sqlOffset)) goto error;
-    if(bwRead((void*) o, len, 1, bw) != 1) goto error;
+    if(bwSetPos(fp, fp->hdr->sqlOffset)) goto error;
+    if(bwRead((void*) o, len, 1, fp) != 1) goto error;
     return o;
 
 error:

--- a/bwStats.c
+++ b/bwStats.c
@@ -8,7 +8,7 @@
 
 //Returns -1 if there are no applicable levels, otherwise an integer indicating the most appropriate level.
 //Like Kent's library, this divides the desired bin size by 2 to minimize the effect of blocks overlapping multiple bins
-static int32_t determineZoomLevel(bigWigFile_t *fp, int basesPerBin) {
+static int32_t determineZoomLevel(const bigWigFile_t *fp, int basesPerBin) {
     int32_t out = -1;
     int64_t diff;
     uint32_t bestDiff = -1;
@@ -420,7 +420,7 @@ static double intSum(bwOverlappingIntervals_t* ints, uint32_t start, uint32_t en
 }
 
 //Returns NULL on error, otherwise a double* that needs to be free()d
-double *bwStatsFromZoom(bigWigFile_t *fp, int32_t level, uint32_t tid, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type) {
+static double *bwStatsFromZoom(bigWigFile_t *fp, int32_t level, uint32_t tid, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type) {
     bwOverlapBlock_t *blocks = NULL;
     double *output = NULL;
     uint32_t pos = start, i, end2;
@@ -482,7 +482,7 @@ error:
     return NULL;
 }
 
-double *bwStatsFromFull(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type) {
+double *bwStatsFromFull(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type) {
     bwOverlappingIntervals_t *ints = NULL;
     double *output = malloc(sizeof(double)*nBins);
     uint32_t i, pos = start, end2;
@@ -527,7 +527,7 @@ double *bwStatsFromFull(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t 
 
 //Returns a list of floats of length nBins that must be free()d
 //On error, NULL is returned
-double *bwStats(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type) {
+double *bwStats(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, uint32_t nBins, enum bwStatsType type) {
     int32_t level = determineZoomLevel(fp, ((double)(end-start))/((int) nBins));
     uint32_t tid = bwGetTid(fp, chrom);
     if(tid == (uint32_t) -1) return NULL;

--- a/bwValues.c
+++ b/bwValues.c
@@ -140,7 +140,7 @@ static bwOverlapBlock_t *overlapsLeaf(bwRTreeNode_t *node, uint32_t tid, uint32_
 
         /*
           The individual blocks can theoretically span multiple contigs.
-          So if we treat the first/last contig in the range as special 
+          So if we treat the first/last contig in the range as special
           but anything in the middle is a guaranteed match
         */
         if(node->chrIdxStart[i] != node->chrIdxEnd[i]) {
@@ -281,7 +281,7 @@ bwOverlapBlock_t *walkRTreeNodes(bigWigFile_t *bw, bwRTreeNode_t *root, uint32_t
 
 //In reality, a hash or some sort of tree structure is probably faster...
 //Return -1 (AKA 0xFFFFFFFF...) on "not there", so we can hold (2^32)-1 items.
-uint32_t bwGetTid(bigWigFile_t *fp, char *chrom) {
+uint32_t bwGetTid(const bigWigFile_t *fp, const char *chrom) {
     uint32_t i;
     if(!chrom) return -1;
     for(i=0; i<fp->cl->nKeys; i++) {
@@ -290,7 +290,7 @@ uint32_t bwGetTid(bigWigFile_t *fp, char *chrom) {
     return -1;
 }
 
-static bwOverlapBlock_t *bwGetOverlappingBlocks(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end) {
+static bwOverlapBlock_t *bwGetOverlappingBlocks(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end) {
     uint32_t tid = bwGetTid(fp, chrom);
 
     if(tid == (uint32_t) -1) {
@@ -437,7 +437,7 @@ bwOverlappingIntervals_t *bwGetOverlappingIntervalsCore(bigWigFile_t *fp, bwOver
         if(hdr.tid != tid) continue;
 
         if(hdr.type == 3) start = hdr.start - hdr.step;
-        
+
         //FIXME: We should ensure that sz is large enough to hold nItems of the given type
         for(j=0; j<hdr.nItems; j++) {
             switch(hdr.type) {
@@ -560,7 +560,7 @@ error:
 }
 
 //Returns NULL on error OR no intervals, which is a bad design...
-bwOverlappingIntervals_t *bwGetOverlappingIntervals(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end) {
+bwOverlappingIntervals_t *bwGetOverlappingIntervals(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end) {
     bwOverlappingIntervals_t *output;
     uint32_t tid = bwGetTid(fp, chrom);
     if(tid == (uint32_t) -1) return NULL;
@@ -572,7 +572,7 @@ bwOverlappingIntervals_t *bwGetOverlappingIntervals(bigWigFile_t *fp, char *chro
 }
 
 //Like above, but for bigBed files
-bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int withString) {
+bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, int withString) {
     bbOverlappingEntries_t *output;
     uint32_t tid = bwGetTid(fp, chrom);
     if(tid == (uint32_t) -1) return NULL;
@@ -584,7 +584,7 @@ bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, char *chrom, u
 }
 
 //Returns NULL on error
-bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, char *chrom, uint32_t start, uint32_t end, uint32_t blocksPerIteration) {
+bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, uint32_t blocksPerIteration) {
     bwOverlapIterator_t *output = NULL;
     uint64_t n;
     uint32_t tid = bwGetTid(bw, chrom);
@@ -612,7 +612,7 @@ bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, char *chro
 }
 
 //Returns NULL on error
-bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *bw, char *chrom, uint32_t start, uint32_t end, int withString, uint32_t blocksPerIteration) {
+bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, int withString, uint32_t blocksPerIteration) {
     bwOverlapIterator_t *output = NULL;
     uint64_t n;
     uint32_t tid = bwGetTid(bw, chrom);
@@ -710,10 +710,10 @@ error:
 //The ->end member is NULL
 //If includeNA is not 0 then ->start is also NULL, since it's implied
 //Note that bwDestroyOverlappingIntervals() will work in either case
-bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t end, int includeNA) {
+bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, int includeNA) {
     uint32_t i, j, n;
     bwOverlappingIntervals_t *output = NULL;
-    bwOverlappingIntervals_t *intermediate = bwGetOverlappingIntervals(fp, chrom, start, end);
+    bwOverlappingIntervals_t *intermediate = bwGetOverlappingIntervals(bw, chrom, start, end);
     if(!intermediate) return NULL;
 
     output = calloc(1, sizeof(bwOverlappingIntervals_t));

--- a/bwValues.c
+++ b/bwValues.c
@@ -584,16 +584,16 @@ bbOverlappingEntries_t *bbGetOverlappingEntries(bigWigFile_t *fp, const char *ch
 }
 
 //Returns NULL on error
-bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, uint32_t blocksPerIteration) {
+bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, uint32_t blocksPerIteration) {
     bwOverlapIterator_t *output = NULL;
     uint64_t n;
-    uint32_t tid = bwGetTid(bw, chrom);
+    uint32_t tid = bwGetTid(fp, chrom);
     if(tid == (uint32_t) -1) return output;
     output = calloc(1, sizeof(bwOverlapIterator_t));
     if(!output) return output;
-    bwOverlapBlock_t *blocks = bwGetOverlappingBlocks(bw, chrom, start, end);
+    bwOverlapBlock_t *blocks = bwGetOverlappingBlocks(fp, chrom, start, end);
 
-    output->bw = bw;
+    output->bw = fp;
     output->tid = tid;
     output->start = start;
     output->end = end;
@@ -603,7 +603,7 @@ bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, const char
     if(blocks) {
         n = blocks->n;
         if(n>blocksPerIteration) blocks->n = blocksPerIteration;
-        output->intervals = bwGetOverlappingIntervalsCore(bw, blocks,tid, start, end);
+        output->intervals = bwGetOverlappingIntervalsCore(fp, blocks,tid, start, end);
         blocks->n = n;
         output->offset = blocksPerIteration;
     }
@@ -612,16 +612,16 @@ bwOverlapIterator_t *bwOverlappingIntervalsIterator(bigWigFile_t *bw, const char
 }
 
 //Returns NULL on error
-bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, int withString, uint32_t blocksPerIteration) {
+bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, int withString, uint32_t blocksPerIteration) {
     bwOverlapIterator_t *output = NULL;
     uint64_t n;
-    uint32_t tid = bwGetTid(bw, chrom);
+    uint32_t tid = bwGetTid(fp, chrom);
     if(tid == (uint32_t) -1) return output;
     output = calloc(1, sizeof(bwOverlapIterator_t));
     if(!output) return output;
-    bwOverlapBlock_t *blocks = bwGetOverlappingBlocks(bw, chrom, start, end);
+    bwOverlapBlock_t *blocks = bwGetOverlappingBlocks(fp, chrom, start, end);
 
-    output->bw = bw;
+    output->bw = fp;
     output->tid = tid;
     output->start = start;
     output->end = end;
@@ -632,7 +632,7 @@ bwOverlapIterator_t *bbOverlappingEntriesIterator(bigWigFile_t *bw, const char *
     if(blocks) {
         n = blocks->n;
         if(n>blocksPerIteration) blocks->n = blocksPerIteration;
-        output->entries = bbGetOverlappingEntriesCore(bw, blocks,tid, start, end, withString);
+        output->entries = bbGetOverlappingEntriesCore(fp, blocks,tid, start, end, withString);
         blocks->n = n;
         output->offset = blocksPerIteration;
     }
@@ -710,10 +710,10 @@ error:
 //The ->end member is NULL
 //If includeNA is not 0 then ->start is also NULL, since it's implied
 //Note that bwDestroyOverlappingIntervals() will work in either case
-bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *bw, const char *chrom, uint32_t start, uint32_t end, int includeNA) {
+bwOverlappingIntervals_t *bwGetValues(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t end, int includeNA) {
     uint32_t i, j, n;
     bwOverlappingIntervals_t *output = NULL;
-    bwOverlappingIntervals_t *intermediate = bwGetOverlappingIntervals(bw, chrom, start, end);
+    bwOverlappingIntervals_t *intermediate = bwGetOverlappingIntervals(fp, chrom, start, end);
     if(!intermediate) return NULL;
 
     output = calloc(1, sizeof(bwOverlappingIntervals_t));

--- a/bwWrite.c
+++ b/bwWrite.c
@@ -19,7 +19,7 @@ struct val_t {
 
 //Create a chromList_t and attach it to a bigWigFile_t *. Returns NULL on error
 //Note that chroms and lengths are duplicated, so you MUST free the input
-chromList_t *bwCreateChromList(char **chroms, uint32_t *lengths, int64_t n) {
+chromList_t *bwCreateChromList(const char* const* chroms, const uint32_t *lengths, int64_t n) {
     int64_t i = 0;
     chromList_t *cl = calloc(1, sizeof(chromList_t));
     if(!cl) return NULL;
@@ -371,9 +371,9 @@ static void updateStats(bigWigFile_t *fp, uint32_t span, float val) {
 }
 
 //12 bytes per entry
-int bwAddIntervals(bigWigFile_t *fp, char **chrom, uint32_t *start, uint32_t *end, float *values, uint32_t n) {
+int bwAddIntervals(bigWigFile_t *fp, const char* const* chrom, const uint32_t *start, const uint32_t *end, const float *values, uint32_t n) {
     uint32_t tid = 0, i;
-    char *lastChrom = NULL;
+    const char *lastChrom = NULL;
     bwWriteBuffer_t *wb = fp->writeBuffer;
     if(!n) return 0; //Not an error per se
     if(!fp->isWrite) return 1;
@@ -431,7 +431,7 @@ int bwAddIntervals(bigWigFile_t *fp, char **chrom, uint32_t *start, uint32_t *en
     return 0;
 }
 
-int bwAppendIntervals(bigWigFile_t *fp, uint32_t *start, uint32_t *end, float *values, uint32_t n) {
+int bwAppendIntervals(bigWigFile_t *fp, const uint32_t *start, const uint32_t *end, const float *values, uint32_t n) {
     uint32_t i;
     bwWriteBuffer_t *wb = fp->writeBuffer;
     if(!n) return 0;
@@ -459,7 +459,7 @@ int bwAppendIntervals(bigWigFile_t *fp, uint32_t *start, uint32_t *end, float *v
 }
 
 //8 bytes per entry
-int bwAddIntervalSpans(bigWigFile_t *fp, char *chrom, uint32_t *start, uint32_t span, float *values, uint32_t n) {
+int bwAddIntervalSpans(bigWigFile_t *fp, const char *chrom, const uint32_t *start, uint32_t span, const float *values, uint32_t n) {
     uint32_t i, tid;
     bwWriteBuffer_t *wb = fp->writeBuffer;
     if(!n) return 0;
@@ -492,7 +492,7 @@ int bwAddIntervalSpans(bigWigFile_t *fp, char *chrom, uint32_t *start, uint32_t 
     return 0;
 }
 
-int bwAppendIntervalSpans(bigWigFile_t *fp, uint32_t *start, float *values, uint32_t n) {
+int bwAppendIntervalSpans(bigWigFile_t *fp, const uint32_t *start, const float *values, uint32_t n) {
     uint32_t i;
     bwWriteBuffer_t *wb = fp->writeBuffer;
     if(!n) return 0;
@@ -517,7 +517,7 @@ int bwAppendIntervalSpans(bigWigFile_t *fp, uint32_t *start, float *values, uint
 }
 
 //4 bytes per entry
-int bwAddIntervalSpanSteps(bigWigFile_t *fp, char *chrom, uint32_t start, uint32_t span, uint32_t step, float *values, uint32_t n) {
+int bwAddIntervalSpanSteps(bigWigFile_t *fp, const char *chrom, uint32_t start, uint32_t span, uint32_t step, const float *values, uint32_t n) {
     uint32_t i, tid;
     bwWriteBuffer_t *wb = fp->writeBuffer;
     if(!n) return 0;
@@ -549,7 +549,7 @@ int bwAddIntervalSpanSteps(bigWigFile_t *fp, char *chrom, uint32_t start, uint32
     return 0;
 }
 
-int bwAppendIntervalSpanSteps(bigWigFile_t *fp, float *values, uint32_t n) {
+int bwAppendIntervalSpanSteps(bigWigFile_t *fp, const float *values, uint32_t n) {
     uint32_t i;
     bwWriteBuffer_t *wb = fp->writeBuffer;
     if(!n) return 0;

--- a/io.c
+++ b/io.c
@@ -12,7 +12,7 @@
 size_t GLOBAL_DEFAULTBUFFERSIZE;
 
 #ifndef NOCURL
-uint64_t getContentLength(URL_t *URL) {
+uint64_t getContentLength(const URL_t *URL) {
     double size;
     if(curl_easy_getinfo(URL->x.curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &size) != CURLE_OK) {
         return 0;
@@ -98,7 +98,7 @@ size_t urlRead(URL_t *URL, void *buf, size_t bufSize) {
 #endif
 }
 
-size_t bwFillBuffer(void *inBuf, size_t l, size_t nmemb, void *pURL) {
+size_t bwFillBuffer(const void *inBuf, size_t l, size_t nmemb, void *pURL) {
     URL_t *URL = (URL_t*) pURL;
     void *p = URL->memBuf;
     size_t copied = l*nmemb;
@@ -158,7 +158,7 @@ CURLcode urlSeek(URL_t *URL, size_t pos) {
 #endif
 }
 
-URL_t *urlOpen(char *fname, CURLcode (*callBack)(CURL*), const char *mode) {
+URL_t *urlOpen(const char *fname, CURLcode (*callBack)(CURL*), const char *mode) {
     URL_t *URL = calloc(1, sizeof(URL_t));
     if(!URL) return NULL;
     char *url = NULL, *req = NULL;

--- a/test/exampleWrite.c
+++ b/test/exampleWrite.c
@@ -2,8 +2,8 @@
 
 int main(int argc, char *argv[]) {
     bigWigFile_t *fp = NULL;
-    char *chroms[] = {"1", "2"};
-    char *chromsUse[] = {"1", "1", "1"};
+    const char *chroms[] = {"1", "2"};
+    const char *chromsUse[] = {"1", "1", "1"};
     uint32_t chrLens[] = {1000000, 1500000};
     uint32_t starts[] = {0, 100, 125,
                          200, 220, 230,

--- a/test/testWrite.c
+++ b/test/testWrite.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     }
 
     if(bwCreateHdr(ofp, 10)) goto error; //ten zoom levels
-    ofp->cl = bwCreateChromList(ifp->cl->chrom, ifp->cl->len, ifp->cl->nKeys);
+    ofp->cl = bwCreateChromList((const char* const*)ifp->cl->chrom, ifp->cl->len, ifp->cl->nKeys);
     if(!ofp->cl) goto error;
 
     if(bwWriteHdr(ofp)) goto error;
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
             chroms = malloc(o->l * sizeof(char*));
             if(!chroms) goto error;
             for(i=0; i<o->l; i++) chroms[i] = ofp->cl->chrom[tid];
-            bwAddIntervals(ofp, chroms, o->start, o->end, o->value, o->l);
+            bwAddIntervals(ofp, (const char* const*)chroms, o->start, o->end, o->value, o->l);
             free(chroms);
         }
         bwDestroyOverlappingIntervals(o);


### PR DESCRIPTION
This PR updates the signature of functions declared in `bigWig.h` and `bigWigIO.h``to take e.g. `const char* const* chroms` instead of `char** chroms` when data can be immutable.

This is especially useful when calling `libBigWig` functions from C++, passing pointers to data stored in containers.

The second commit part of this PR applies some suggestion from my IDE to make param naming consistent across declaration and implementation.